### PR TITLE
lets try adding a buildsi namespace to containers

### DIFF
--- a/containers/buildsi/m/buildsi-mpich/Dockerfile
+++ b/containers/buildsi/m/buildsi-mpich/Dockerfile
@@ -1,6 +1,6 @@
 FROM spack/ubuntu-bionic:latest
 
-RUN spack install mpich@3.4.1
+RUN spack install mpich@3.4.1 \
 &&  spack install mpich@3.3.2 \
 &&  spack install mpich@3.1.4 device=ch3 netmod=tcp \
 &&  spack install mpich@3.0.4 device=ch3 netmod=tcp

--- a/containers/buildsi/m/buildsi-mpich/Dockerfile
+++ b/containers/buildsi/m/buildsi-mpich/Dockerfile
@@ -1,0 +1,8 @@
+FROM spack/ubuntu-bionic:latest
+
+RUN spack install mpich@3.4.1
+&&  spack install mpich@3.3.2 \
+&&  spack install mpich@3.1.4 device=ch3 netmod=tcp \
+&&  spack install mpich@3.0.4 device=ch3 netmod=tcp
+
+ENV PACKAGE_VERSIONS="3.4.1 3.3.2 3.1.4 3.0.4"


### PR DESCRIPTION
This is a smaller version of the mpich container - it's also under a new namespace for buildsi so that if this works I'll likely close the other PR - we definitely want to keep these buildsi containers separate from the rest, at least by namespace.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>