### PR TITLE
Update gromacs to include missing libgomp dependency.

### DIFF
--- a/containers/g/gromacs/spack.yaml
+++ b/containers/g/gromacs/spack.yaml
@@ -1,3 +1,8 @@
 spack:
   specs: 
-    - gromacs
+    - gromacs+mpi
+    - mpich
+  container:
+    os_packages:
+      final:
+        - libgomp1


### PR DESCRIPTION
It looks like Spack can't build `libgomp` from source yet so we'll have to bootstrap it from the Ubuntu archives for the moment.