### PR TITLE
Update lammps to include missing libgomp dependency

### DIFF
--- a/containers/l/lammps/spack.yaml
+++ b/containers/l/lammps/spack.yaml
@@ -1,3 +1,8 @@
 spack:
   specs: 
-    - lammps
+    - lammps+mpi
+    - mpich
+  container:
+    os_packages:
+      final:
+        - libgomp1


### PR DESCRIPTION
```bash
docker run --rm -it ghcr.io/autamus/lammps:latest lmp
lmp: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory
```
The LAMMPS container seems to have the same issues as #368 