### PR TITLE
Fix abi-dumper dependency

### DIFF
--- a/spack/u/universal-ctags/package.py
+++ b/spack/u/universal-ctags/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class UniversalCtags(AutotoolsPackage):
+    """Universal Ctags generates an index (or tag) file of language
+    objects found in source files for many popular programming languages.
+    This index makes it easy for text editors and other tools to locate
+    the indexed items."""
+
+    homepage = "https://ctags.io/"
+    git      = "https://github.com/universal-ctags/ctags.git"
+
+    version('master', branch='master')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+    depends_on('libiconv', type='link')
+    depends_on('pkg-config', type='build')


### PR DESCRIPTION
Add `pkg-config` as a dependency to universal-ctags to fix abi-dumper build.